### PR TITLE
Fix visualization script for gzipped data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ The frontend will be available at `http://localhost:5173` by default and is conf
 
 ## Elevation Visualization
 
-To visualize `.hgt` files located in `backend/data`, install the backend dependencies and run the visualization script:
+To visualize elevation tiles (`.hgt` or `.hgt.gz`) located in `backend/data`, install the backend dependencies and run the visualization script:
 
 ```
 cd backend
@@ -38,3 +38,5 @@ python visualize_hgt.py
 ```
 
 The script loads all `.hgt` tiles from the `data` folder and opens an interactive 3D surface plot using Plotly. Use the mouse to rotate along the x, y, and z axes.
+
+Files compressed with `gzip` (`.hgt.gz`) are supported and will be decompressed automatically.


### PR DESCRIPTION
## Summary
- allow `.hgt.gz` files and mask nodata in elevation visualizer
- document gzipped tile support in README

## Testing
- `python -m py_compile backend/main.py backend/visualize_hgt.py`
- `python backend/visualize_hgt.py`

------
https://chatgpt.com/codex/tasks/task_e_6847090570dc832bbeb6ec6fed8ae132