### PR TITLE
Fix elevation plot rendering

### DIFF
--- a/backend/visualize_hgt.py
+++ b/backend/visualize_hgt.py
@@ -71,7 +71,9 @@ def plot_elevation(lat, lon, elevation):
             zaxis_title='Elevation (m)'
         ),
     )
-    fig.show()
+    output_html = os.path.join(os.path.dirname(__file__), 'elevation_plot.html')
+    fig.write_html(output_html, auto_open=True)
+    print(f'Saved plot to {output_html}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow `visualize_hgt.py` to save the plot to an HTML file

## Testing
- `python -m py_compile backend/main.py backend/visualize_hgt.py`
- `python backend/visualize_hgt.py`

------
https://chatgpt.com/codex/tasks/task_e_68470edc80e8832b80830fca68a4db68