### PR TITLE
Add vertical exaggeration control for elevation plots

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,4 +39,7 @@ python visualize_hgt.py
 
 The script loads all `.hgt` tiles from the `data` folder and opens an interactive 3D surface plot using Plotly. Use the mouse to rotate along the x, y, and z axes.
 
+Pass `--exaggeration` to control vertical exaggeration of the terrain. Values
+less than `1.0` flatten the plot (default is `0.02`).
+
 Files compressed with `gzip` (`.hgt.gz`) are supported and will be decompressed automatically.


### PR DESCRIPTION
## Summary
- add `DEFAULT_EXAGGERATION` constant and CLI argument in `visualize_hgt.py`
- allow scaling of the z-axis so the landscape isn't overly steep
- document the `--exaggeration` option in the README

## Testing
- `python -m py_compile backend/visualize_hgt.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684750248000832ba784bccd601a697b