### PR TITLE
Update color scheme for elevation plot

### DIFF
--- a/backend/visualize_hgt.py
+++ b/backend/visualize_hgt.py
@@ -118,7 +118,13 @@ def plot_elevation(lat, lon, elevation, exaggeration: float = DEFAULT_EXAGGERATI
 
     fig = go.Figure()
     for level in exag_levels:
-        fig.add_surface(z=elevation * level, x=lon, y=lat, visible=False)
+        fig.add_surface(
+            z=elevation * level,
+            x=lon,
+            y=lat,
+            visible=False,
+            colorscale="Earth",
+        )
 
     start_index = exag_levels.index(exaggeration)
     fig.data[start_index].visible = True


### PR DESCRIPTION
## Summary
- tweak the Plotly surface colorscale to use `Earth` in `visualize_hgt.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847559fa1f0832ba24ac06a35c4187e